### PR TITLE
Implement MPLS Switching

### DIFF
--- a/Example6-MPLSSwitching/.gitignore
+++ b/Example6-MPLSSwitching/.gitignore
@@ -1,0 +1,5 @@
+p4src/*.p4i
+p4src/*.json
+pcap/
+log/
+topology.json

--- a/Example6-MPLSSwitching/README.md
+++ b/Example6-MPLSSwitching/README.md
@@ -1,7 +1,21 @@
 # Example 6: Multiprotocol Lable-Switching
 This example showcases how P4 can be used to implement MPLS-Switching utilizing the Network API from p4utils.
+It shows how one could use P4 to implement a custom protocol and perform forwarding based on its header. In this case, a very simple form
+of Multi Protocol Label Switching is performed. Packets can be given a Label and be routed a specific way based on table entries.
+
+In this example, IPv4 traffic from ```h1``` to ```h3``` will always be routed over the shorter way using s4. This works by pushing a label on packets depending on the destination IP.
 
 ## Usage
+It's assumed that you run this example in a VM, container or host that supports the necessary P4 tools. Otherwise please install all depencies as described for p4-boilerplate and p4environment (as described in the main README) or consider using p4-container. If you choose p4-container, be advised, that its support to run p4environment is limited, due to limitations for netem and openvswitch inside typical container environments.
+```
+cd p4-boilerplate/Example6-MPLS-Switching
+sudo python3 network.py
+```
+This sets up the topology and drops you to a mininet console. You can ping ```h3``` from ```h1```:
+```
+mininet> h1 ping h3
+```
+You can verify by looking at the logs that indeed the packets were sent over ```s4```, according to a label that gets added to the packets.
 
 ## Topology
 ```mermaid

--- a/Example6-MPLSSwitching/README.md
+++ b/Example6-MPLSSwitching/README.md
@@ -1,0 +1,18 @@
+# Example 6: Multiprotocol Lable-Switching
+This example showcases how P4 can be used to implement MPLS-Switching utilizing the Network API from p4utils.
+
+## Usage
+
+## Topology
+```mermaid
+flowchart TD
+    A[h1] --> B(s1)
+    B --> C(s2)
+    B --> F(s4)
+    F --> G(s5)
+    G --> H(h3)
+    C --> D(s3)
+    D --> E[H2]
+```
+
+The topology consists of three hosts that are connected via switches as seen in the figure above.

--- a/Example6-MPLSSwitching/README.md
+++ b/Example6-MPLSSwitching/README.md
@@ -5,14 +5,15 @@ This example showcases how P4 can be used to implement MPLS-Switching utilizing 
 
 ## Topology
 ```mermaid
-flowchart TD
-    A[h1] --> B(s1)
-    B --> C(s2)
-    B --> F(s4)
-    F --> G(s5)
-    G --> H(h3)
-    C --> D(s3)
-    D --> E[H2]
+graph LR
+	A[h1] --- B[s1]
+	C[h2] --- B[s1]
+	B[s1] --- D[s2]
+	B[s1] --- E[s4]
+	D[s2] --- F[s3]
+	F[s3] --- G[h3]
+	E[s4] --- G[s5]
+	G[s5] --- H[h3]
 ```
 
 The topology consists of three hosts that are connected via switches as seen in the figure above.

--- a/Example6-MPLSSwitching/network.py
+++ b/Example6-MPLSSwitching/network.py
@@ -1,0 +1,34 @@
+from p4utils.mininetlib.network_API import NetworkAPI
+
+class Example6Topo(object):
+
+    def __init__(self):
+        self.network = NetworkAPI()
+        # add P4 Switches to Network Topology
+        for i in range(5):
+            self.network.addP4Switch('s' + str((i + 1)))
+        # add two hosts to the Networks Topology
+        for i in range(3):
+            self.network.addHost('h' + str((i + 1)))
+        self.network.setP4SourceAll('./p4src/mpls.p4')
+        self.network.mixed()
+
+        # connect the network components as specified by the diagram in README.md
+        self.network.addLink('h1', 's1')
+        self.network.addLink('s1', 's2')
+        self.network.addLink('s1', 's4')
+        self.network.addLink('s2', 's3')
+        self.network.addLink('s3', 'h2')
+        self.network.addLink('s4', 's5')
+        self.network.addLink('s5', 'h3')
+
+        # enable pcaps and logging
+        self.network.enablePcapDumpAll()
+        self.network.enableLogAll()
+    
+    def run(self):
+        self.network.enableCli()
+        self.network.startNetwork()
+
+if __name__ == '__main__':
+    Example6Topo().run()

--- a/Example6-MPLSSwitching/network.py
+++ b/Example6-MPLSSwitching/network.py
@@ -6,12 +6,12 @@ class Example6Topo(object):
         self.network = NetworkAPI()
         # add P4 Switches to Network Topology
         for i in range(5):
-            self.network.addP4Switch('s' + str((i + 1)))
+            self.network.addP4Switch('s' + str((i + 1)), cli_input='s{number}-commands.txt'.format(number = i + 1))
         # add two hosts to the Networks Topology
         for i in range(3):
             self.network.addHost('h' + str((i + 1)))
         self.network.setP4SourceAll('./p4src/mpls.p4')
-        self.network.mixed()
+        
 
         # connect the network components as specified by the diagram in README.md
         self.network.addLink('h1', 's1')
@@ -23,6 +23,7 @@ class Example6Topo(object):
         self.network.addLink('s4', 's5')
         self.network.addLink('s5', 'h3')
 
+        self.network.l3()
         # enable pcaps and logging
         self.network.enablePcapDumpAll()
         self.network.enableLogAll()

--- a/Example6-MPLSSwitching/network.py
+++ b/Example6-MPLSSwitching/network.py
@@ -15,10 +15,11 @@ class Example6Topo(object):
 
         # connect the network components as specified by the diagram in README.md
         self.network.addLink('h1', 's1')
+        self.network.addLink('h2', 's1')
         self.network.addLink('s1', 's2')
-        self.network.addLink('s1', 's4')
         self.network.addLink('s2', 's3')
-        self.network.addLink('s3', 'h2')
+        self.network.addLink('s3', 's5')
+        self.network.addLink('s1', 's4')
         self.network.addLink('s4', 's5')
         self.network.addLink('s5', 'h3')
 

--- a/Example6-MPLSSwitching/p4src/mpls.p4
+++ b/Example6-MPLSSwitching/p4src/mpls.p4
@@ -1,0 +1,107 @@
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<16> etherType_t;
+typedef bit<48> macAddr_t;
+typedef bit<32> ipv4Addr_t;
+
+const etherType_t IPV4_ETHER_TYPE = 0x0800;
+const etherType_t MPLS_ETHER_TYPE = 0x8847;
+
+header ethernet_t {
+    macAddr_t dstAddr;
+    macAddr_t srcAddr;
+    etherType_t ethertype;
+}
+
+header ipv4_t {
+    bit<4> version;
+    bit<4> ipHeaderLen;
+    bit<8> differentiatedServices;
+    bit<16> totalLength;
+    bit<16> identification;
+    bit<3> flags;
+    bit<13> fragmentOffset;
+    bit<8> ttl;
+    bit<8> protocol;
+    bit<16> headerChecksum;
+    ipv4Addr_t srcAddr;
+    ipv4Addr_t destAddr;
+    // options could go here, but are omitted.
+}
+
+header mplsLabel_t {
+    bit<20> label;
+    bit<3> trafficClass;
+    bit<1> bottomOfStack;
+    bit<8> ttl;
+}
+
+struct Headers {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+    mplsLabel_t mpls;
+}
+
+// Metadata can stay empty
+struct Metadata {
+}
+
+parser MyParser(packet_in pkt, out Headers hdr, inout Metadata meta, inout standard_metadata_t std_meta) {
+    state start {
+        transition parse_ethernet;
+    }
+
+    state parse_ethernet {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.ethertype) {
+            IPV4_ETHER_TYPE: parse_ipv4;
+            MPLS_ETHER_TYPE: parse_mpls;
+            default: accept;
+        }
+    }
+
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+
+    state parse_mpls {
+        pkt.extract(hdr.mpls);
+        transition parse_ipv4;
+    }
+}
+
+control MyVerifyChecksum(inout Headers hdr, inout Metadata meta) { apply { } }
+
+control MyIngress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t std_meta) {
+    apply {}
+}
+
+control MyEgress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t std_meta) {
+    apply {}
+}
+
+control MyComputeChecksum(inout Headers hdr, inout Metadata meta) {
+    apply { }
+}
+
+control MyDeparser(packet_out pkt, in Headers hdr) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.mpls);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+V1Switch(
+    MyParser(),
+    MyVerifyChecksum(),
+    MyIngress(),
+    MyEgress(),
+    MyComputeChecksum(),
+    MyDeparser()
+) main;
+
+
+

--- a/Example6-MPLSSwitching/s1-commands.txt
+++ b/Example6-MPLSSwitching/s1-commands.txt
@@ -1,3 +1,3 @@
-table_add mpls_exact mpls_forward 1 10 => 4
 table_add ipv4_lpm ipv4_forward 10.1.1.2/24 => 00:00:0a:01:01:02 1
 table_add ipv4_lpm ipv4_forward 10.1.2.2/24 => 00:00:0a:01:02:02 2
+table_add ipv4_lpm mpls_begin 10.5.3.2/24 => 10 4

--- a/Example6-MPLSSwitching/s1-commands.txt
+++ b/Example6-MPLSSwitching/s1-commands.txt
@@ -1,0 +1,3 @@
+table_add mpls_exact mpls_forward 1 10 => 4
+table_add ipv4_lpm ipv4_forward 10.1.1.2/24 => 00:00:0a:01:01:02 1
+table_add ipv4_lpm ipv4_forward 10.1.2.2/24 => 00:00:0a:01:02:02 2

--- a/Example6-MPLSSwitching/s2-commands.txt
+++ b/Example6-MPLSSwitching/s2-commands.txt
@@ -1,0 +1,3 @@
+table_add mpls_exact mpls_end 2 10 => 1
+table_add mpls_exact mpls_forward 1 10 => 2
+  

--- a/Example6-MPLSSwitching/s3-commands.txt
+++ b/Example6-MPLSSwitching/s3-commands.txt
@@ -1,0 +1,2 @@
+table_add mpls_exact mpls_end 1 10 => 2
+table_add mpls_exact mpls_forward 2 10 => 1

--- a/Example6-MPLSSwitching/s4-commands.txt
+++ b/Example6-MPLSSwitching/s4-commands.txt
@@ -1,0 +1,2 @@
+table_add mpls_exact mpls_end 1 10 => 2
+table_add mpls_exact mpls_end 2 10 => 1

--- a/Example6-MPLSSwitching/s5-commands.txt
+++ b/Example6-MPLSSwitching/s5-commands.txt
@@ -1,0 +1,2 @@
+table_add mpls_exact mpls_forward 3 10 => 2
+table_add ipv4_lpm ipv4_forward 10.0.0.3/8 => 56:6d:ad:2b:a2:61 3

--- a/Example6-MPLSSwitching/s5-commands.txt
+++ b/Example6-MPLSSwitching/s5-commands.txt
@@ -1,2 +1,2 @@
-table_add mpls_exact mpls_forward 3 10 => 2
-table_add ipv4_lpm ipv4_forward 10.0.0.3/8 => 56:6d:ad:2b:a2:61 3
+table_add ipv4_lpm mpls_begin 10.1.1.2/24 => 10 2
+table_add ipv4_lpm ipv4_forward 10.5.3.2/24 => 00:00:0a:05:03:02 3


### PR DESCRIPTION
# MPLS Switching
This PR implements a very simple form of MPLS-Switching in P4. It demonstrates how one could implement a custom protocol using P4. This example works by appending a custom header based on the destination IP address and then performing routing based on it.

The label gets removed based on a table entry when the packet is about to arrive at a switch connected to hosts.

## Topology used in this Example
```mermaid
graph LR
	A[h1] --- B[s1]
	C[h2] --- B[s1]
	B[s1] --- D[s2]
	B[s1] --- E[s4]
	D[s2] --- F[s3]
	F[s3] --- G[h3]
	E[s4] --- G[s5]
	G[s5] --- H[h3]
```
